### PR TITLE
Append CSV metrics output instead of overwriting

### DIFF
--- a/locust/main.py
+++ b/locust/main.py
@@ -72,6 +72,15 @@ def parse_options():
         help="Store current request stats to files in CSV format.",
     )
 
+    # if locust should append the CSV file instead of replacing it.
+    parser.add_option(
+        '--csv-append',
+        action='store_true',
+        dest='csvappend',
+        default=False,
+        help="Set locust to append CSV file at set interval instead of replacing.",
+    )
+
     # if locust should be run in distributed mode as master
     parser.add_option(
         '--master',
@@ -481,15 +490,17 @@ def main():
         except socket.error as e:
             logger.error("Failed to connect to the Locust master: %s", e)
             sys.exit(-1)
-    
+
     if not options.only_summary and (options.print_stats or (options.no_web and not options.slave)):
         # spawn stats printing greenlet
         gevent.spawn(stats_printer)
 
     if options.csvfilebase:
-        gevent.spawn(stats_writer, options.csvfilebase)
+        gevent.spawn(stats_writer,
+                     options.csvfilebase,
+                     options.csvappend)
 
-    
+
     def shutdown(code=0):
         """
         Shut down locust by firing quitting event, printing/writing stats and exiting
@@ -500,7 +511,8 @@ def main():
         print_stats(runners.locust_runner.request_stats)
         print_percentile_stats(runners.locust_runner.request_stats)
         if options.csvfilebase:
-            write_stat_csvs(options.csvfilebase)
+            write_stat_csvs(options.csvfilebase,
+                            options.csvappend)
         print_error_report()
         sys.exit(code)
     

--- a/locust/runners.py
+++ b/locust/runners.py
@@ -40,13 +40,15 @@ class LocustRunner(object):
         self.hatching_greenlet = None
         self.exceptions = {}
         self.stats = global_stats
-        
+        self.runner_start_time = time()
+
         # register listener that resets stats when hatching is complete
         def on_hatch_complete(user_count):
             self.state = STATE_RUNNING
             if self.options.reset_stats:
                 logger.info("Resetting stats\n")
                 self.stats.reset_all()
+                self.runner_start_time = time()
         events.hatch_complete += on_hatch_complete
 
     @property

--- a/locust/stats.py
+++ b/locust/stats.py
@@ -16,7 +16,7 @@ STATS_NAME_WIDTH = 60
 
 """Default interval for how frequently the CSV file is written if this option
 is configured."""
-CSV_STATS_INTERVAL_SEC = 2
+CSV_STATS_INTERVAL_SEC = 10
 
 """Default interval for how frequently results are written to console."""
 CONSOLE_STATS_INTERVAL_SEC = 2
@@ -406,6 +406,7 @@ class StatsEntry(object):
         
         Percent specified in range: 0.0 - 1.0
         """
+
         return calculate_response_time_percentile(self.response_times, self.num_requests, percent)
     
     def get_current_response_time_percentile(self, percent):
@@ -445,13 +446,15 @@ class StatsEntry(object):
                 self.num_requests - cached.num_requests, 
                 percent,
             )
-    
-    def percentile(self, tpl=" %-" + str(STATS_NAME_WIDTH) + "s %8d %6d %6d %6d %6d %6d %6d %6d %6d %6d"):
+
+
+    def percentile(self, tpl=" %-" + str(STATS_NAME_WIDTH) + "s %8d %6d %6d %6d %6d %6d %6d %6d %6d %6d %6d", elapsed_time=0):
         if not self.num_requests:
             raise ValueError("Can't calculate percentile on url with no successful requests")
-        
+
         return tpl % (
             (self.method and self.method + " " or "") + self.name,
+            elapsed_time,
             self.num_requests,
             self.get_response_time_percentile(0.5),
             self.get_response_time_percentile(0.66),
@@ -655,34 +658,45 @@ def stats_printer():
         print_stats(runners.locust_runner.request_stats)
         gevent.sleep(CONSOLE_STATS_INTERVAL_SEC)
 
-def stats_writer(base_filepath):
-    """Writes the csv files for the locust run."""
+def stats_writer(base_filepath, append_file=False):
+    """Writes the csv files for the locust run.""" 
+    write_stat_csvs(base_filepath, include_totals=(not append_file))
     while True:
-        write_stat_csvs(base_filepath)
         gevent.sleep(CSV_STATS_INTERVAL_SEC)
+        write_stat_csvs(base_filepath, append_file, include_totals=(not append_file))
 
 
-def write_stat_csvs(base_filepath):
-    """Writes the requests and distribution csvs."""
-    with open(base_filepath + '_requests.csv', "w") as f:
-        f.write(requests_csv())
+def write_stat_csvs(base_filepath, append_file=False, include_totals=True):
+    """
+    Writes the requests and distribution CSV files.
 
-    with open(base_filepath + '_distribution.csv', 'w') as f:
-        f.write(distribution_csv())
+    By default overwrites the existing file,
+    optionally appends the existing file
+    """
+
+    file_mode = "a" if append_file else "w"
+
+    with open(base_filepath + '_requests.csv', file_mode) as f:
+        f.write(requests_csv(append_file, include_totals) + "\n")
+
+    with open(base_filepath + '_distribution.csv', file_mode) as f:
+        f.write(distribution_csv(append_file, include_totals) + "\n")
 
 
 def sort_stats(stats):
     return [stats[key] for key in sorted(six.iterkeys(stats))]
 
 
-def requests_csv():
+def requests_csv(append_file=False, include_totals=True):
     from . import runners
 
     """Returns the contents of the 'requests' tab as CSV."""
-    rows = [
-        ",".join([
+    rows = []
+    if not append_file:
+        rows.append(",".join([
             '"Method"',
             '"Name"',
+            '"Total elapsed time"',
             '"# requests"',
             '"# failures"',
             '"Median response time"',
@@ -692,12 +706,17 @@ def requests_csv():
             '"Average Content Size"',
             '"Requests/s"',
         ])
-    ]
+    )
 
-    for s in chain(sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.total]):
-        rows.append('"%s","%s",%i,%i,%i,%i,%i,%i,%i,%.2f' % (
+    maybe_agg_stats = [] 
+    if include_totals:
+        maybe_agg_stats = [runners.locust_runner.stats.total]
+    elapsed_time = int(time.time()) - runners.locust_runner.runner_start_time
+    for s in chain(sort_stats(runners.locust_runner.request_stats), maybe_agg_stats):
+        rows.append('"%s","%s",%i,%i,%i,%i,%i,%i,%i,%i,%.2f' % (
             s.method,
             s.name,
+            elapsed_time,
             s.num_requests,
             s.num_failures,
             s.median_response_time,
@@ -709,12 +728,16 @@ def requests_csv():
         ))
     return "\n".join(rows)
 
-def distribution_csv():
+
+def distribution_csv(append_file=False, include_totals=True):
     """Returns the contents of the 'distribution' tab as CSV."""
     from . import runners
 
-    rows = [",".join((
+    rows = []
+    if not append_file:
+        rows.append(",".join((
         '"Name"',
+        '"Total elapsed time"',
         '"# requests"',
         '"50%"',
         '"66%"',
@@ -725,11 +748,18 @@ def distribution_csv():
         '"98%"',
         '"99%"',
         '"100%"',
-    ))]
-    for s in chain(sort_stats(runners.locust_runner.request_stats), [runners.locust_runner.stats.total]):
+    )))
+
+    maybe_agg_stats = []
+    if include_totals:
+        maybe_agg_stats = [runners.locust_runner.stats.total]
+    elapsed_time = int(time.time()) - runners.locust_runner.runner_start_time
+    for s in chain(sort_stats(runners.locust_runner.request_stats), maybe_agg_stats):
         if s.num_requests:
-            rows.append(s.percentile(tpl='"%s",%i,%i,%i,%i,%i,%i,%i,%i,%i,%i'))
+            rows.append(s.percentile(tpl='"%s",%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i',
+                                     elapsed_time=elapsed_time)
+                        )
         else:
-            rows.append('"%s",0,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"' % s.name)
+            rows.append('"%s",0,%i,"N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A","N/A"' % (s.name,elapsed_time))
 
     return "\n".join(rows)

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -120,13 +120,13 @@ class TestRequestStats(unittest.TestCase):
         s1 = StatsEntry(self.stats, "rounding down!", "GET")
         s1.log(122, 0)    # (rounded 120) min
         actual_percentile = s1.percentile()
-        self.assertEqual(actual_percentile, " GET rounding down!                                                  1    120    120    120    120    120    120    120    120    120")
+        self.assertEqual(actual_percentile, " GET rounding down!                                                  0      1    120    120    120    120    120    120    120    120    120")
 
     def test_percentile_rounded_up(self):
         s2 = StatsEntry(self.stats, "rounding up!", "GET")
         s2.log(127, 0)    # (rounded 130) min
         actual_percentile = s2.percentile()
-        self.assertEqual(actual_percentile, " GET rounding up!                                                    1    130    130    130    130    130    130    130    130    130")
+        self.assertEqual(actual_percentile, " GET rounding up!                                                    0      1    130    130    130    130    130    130    130    130    130")
     
     def test_error_grouping(self):
         # reset stats


### PR DESCRIPTION
Adds `--csv-append` flag to enable appending of the metrics CSV log. This allows for tracking changes in response times over the course of long test runs.